### PR TITLE
Swagger UIの実装

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -100,7 +100,7 @@ func SetupRouter(taskController *controller.TaskController) http.Handler {
 	})
 
 	// Swagger UI
-	mux.Handle("/swagger/", http.StripPrefix("/swagger", NewSwaggerHandler()))
+	mux.Handle("/swagger/", NewSwaggerHandler())
 
 	return mux
 }

--- a/internal/api/swagger.go
+++ b/internal/api/swagger.go
@@ -9,7 +9,7 @@ import (
 // NewSwaggerHandler Swagger UIを提供するハンドラーを作成
 func NewSwaggerHandler() http.Handler {
 	return httpSwagger.Handler(
-		httpSwagger.URL("../doc.json"), // Swaggerドキュメントのパス
+		httpSwagger.URL("doc.json"), // Swaggerドキュメントのパス
 		httpSwagger.DeepLinking(true),
 		httpSwagger.DocExpansion("none"),
 		httpSwagger.DomID("swagger-ui"),

--- a/internal/api/swagger.go
+++ b/internal/api/swagger.go
@@ -9,7 +9,7 @@ import (
 // NewSwaggerHandler Swagger UIを提供するハンドラーを作成
 func NewSwaggerHandler() http.Handler {
 	return httpSwagger.Handler(
-		httpSwagger.URL("doc.json"), // Swaggerドキュメントのパス
+		httpSwagger.URL(""), // Swaggerドキュメントのパス
 		httpSwagger.DeepLinking(true),
 		httpSwagger.DocExpansion("none"),
 		httpSwagger.DomID("swagger-ui"),

--- a/internal/api/swagger.go
+++ b/internal/api/swagger.go
@@ -9,7 +9,7 @@ import (
 // NewSwaggerHandler Swagger UIを提供するハンドラーを作成
 func NewSwaggerHandler() http.Handler {
 	return httpSwagger.Handler(
-		httpSwagger.URL("./doc.json"), // Swaggerドキュメントのパス
+		httpSwagger.URL("../doc.json"), // Swaggerドキュメントのパス
 		httpSwagger.DeepLinking(true),
 		httpSwagger.DocExpansion("none"),
 		httpSwagger.DomID("swagger-ui"),

--- a/internal/api/swagger.go
+++ b/internal/api/swagger.go
@@ -9,7 +9,7 @@ import (
 // NewSwaggerHandler Swagger UIを提供するハンドラーを作成
 func NewSwaggerHandler() http.Handler {
 	return httpSwagger.Handler(
-		httpSwagger.URL("swagger.json"), // Swaggerドキュメントのパス
+		httpSwagger.URL("doc.json"), // Swaggerドキュメントのパス
 		httpSwagger.DeepLinking(true),
 		httpSwagger.DocExpansion("none"),
 		httpSwagger.DomID("swagger-ui"),

--- a/internal/api/swagger.go
+++ b/internal/api/swagger.go
@@ -9,7 +9,7 @@ import (
 // NewSwaggerHandler Swagger UIを提供するハンドラーを作成
 func NewSwaggerHandler() http.Handler {
 	return httpSwagger.Handler(
-		httpSwagger.URL(""), // Swaggerドキュメントのパス
+		httpSwagger.URL("swagger.json"), // Swaggerドキュメントのパス
 		httpSwagger.DeepLinking(true),
 		httpSwagger.DocExpansion("none"),
 		httpSwagger.DomID("swagger-ui"),


### PR DESCRIPTION
1. prefixの削除処理を除く @internal/api/router.go
2. ドキュメントパスを`doc.json`にする @internal/api/swagger.go